### PR TITLE
feat: add runtimeClassName

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,7 +4,7 @@ description: Get up and running with large language models locally.
 
 type: application
 
-version: 0.10.1
+version: 0.10.2
 
 appVersion: "0.1.20"
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       serviceAccountName: {{ include "ollama.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -48,6 +48,8 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+runtimeClassName: ""
+
 service:
   type: ClusterIP
   port: 11434


### PR DESCRIPTION
To enhance the scheduling of Ollama on nodes within my cluster, which features a variety of node types, the ability to specify the runtimeClassName would be greatly beneficial