### PR TITLE
Feat: add multiple models at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Substitute your values if they differ from the examples. See `helm delete --help
 ## Examples
 - **It's highly recommended to run an updated version of Kubernetes for deploying ollama with GPU**
 
-### Basic values.yaml example with GPU and default model
+### Basic values.yaml example with GPU and two models pull at startup
 ```
 ollama:
   gpu:
@@ -65,14 +65,17 @@ ollama:
     enabled: true
     # -- Specify the number of GPU to 2
     number: 2
-  # -- Set default model to mistral
-  defaultModel: "mistral"
+  # -- List of models to pull at container startup
+  models: 
+    - mistral
+    - llama2
 ```
 ---
 ### Basic values.yaml example with Ingress
 ```
 ollama:
-  defaultModel: "llama2"
+  models:
+    - llama2
 ingress:
   enabled: true
     hosts:
@@ -82,7 +85,7 @@ ingress:
           pathType: Prefix
 ```
 
-- *APi is now reachable at `ollama.domain.lan`*
+- *API is now reachable at `ollama.domain.lan`*
 
 ## Helm Values
 
@@ -117,9 +120,10 @@ ingress:
 | livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe |
 | nameOverride | string | `""` | String to partially override template  (will maintain the release name) |
 | nodeSelector | object | `{}` | Node labels for pod assignment. |
-| ollama.defaultModel | string | `"llama2"` | Default model to serve, if not set, no model will be served at container startup |
 | ollama.gpu.enabled | bool | `false` | Enable GPU integration |
 | ollama.gpu.number | int | `1` | Specify the number of GPU |
+| ollama.insecure | bool | `false` | Add insecure flag for pulling at container startup |
+| ollama.models | list | `["llama2"]` | List of models to pull at container startup |
 | persistentVolume.accessModes | list | `["ReadWriteOnce"]` | Ollama server data Persistent Volume access modes Must match those of existing PV or dynamic provisioner Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/ |
 | persistentVolume.annotations | object | `{}` | Ollama server data Persistent Volume annotations |
 | persistentVolume.enabled | bool | `false` | Enable persistence using PVC |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -60,3 +60,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the model list
+*/}}
+{{- define "ollama.modelList" -}}
+{{- $modelList := default list}}
+{{- if .Values.ollama.models}}
+{{- $modelList = concat $modelList .Values.ollama.models }}
+{{- end}}
+{{- if .Values.ollama.defaultModel}}
+{{- $modelList = append $modelList .Values.ollama.defaultModel }}
+{{- end}}
+{{- $modelList = $modelList | uniq}}
+{{- default (join " " $modelList) -}}
+{{- end -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -94,11 +94,11 @@ spec:
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}
-          {{- if .Values.ollama.defaultModel }}
+          {{- if or .Values.ollama.models .Values.ollama.defaultModel }}
           lifecycle:
             postStart:
               exec:
-                command: ["/bin/ollama", "pull", "{{ .Values.ollama.defaultModel }}"]
+                command: [ "/bin/sh", "-c", "{{- printf "echo %s | xargs -n1 /bin/ollama pull %s" (include "ollama.modelList" .) (ternary "--insecure" "" .Values.ollama.insecure)}}" ]
           {{- end }}
       volumes:
         - name: ollama-data

--- a/values.yaml
+++ b/values.yaml
@@ -34,8 +34,13 @@ ollama:
     # -- Specify the number of GPU
     number: 1
 
-  # -- Default model to serve, if not set, no model will be served at container startup
-  defaultModel: "llama2"
+  # -- List of models to pull at container startup
+  models:
+    - llama2
+    - mistral
+
+  # -- Add insecure flag for pulling at container startup
+  insecure: false
 
 # Service account
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/


### PR DESCRIPTION
Feats:
 - add key `ollama.models` for pulling a list of model at startup
 - add key `ollama.insecure` for insecure pull flag

Changes:
- the `ollama.defaultModel` still works with `ollama.models` but not recommended

Docs:
- update examples and helm values