### PR TITLE
remove default resources definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ ingress:
 | readinessProbe.successThreshold | int | `1` | Success threshold for readinessProbe |
 | readinessProbe.timeoutSeconds | int | `3` | Timeout seconds for readinessProbe |
 | replicaCount | int | `1` | Number of replicas |
-| resources.limits.cpu | string | `"4000m"` | CPU limit |
-| resources.limits.memory | string | `"8192Mi"` | Memory limit |
-| resources.requests.cpu | string | `"2000m"` | CPU request |
-| resources.requests.memory | string | `"4096Mi"` | Memory request |
+| resources.limits.cpu | string | `""` | CPU limit |
+| resources.limits.memory | string | `""` | Memory limit |
+| resources.requests.cpu | string | `""` | CPU request |
+| resources.requests.memory | string | `""` | Memory request |
 | runtimeClassName | string | `""` | Specify runtime class |
 | securityContext | object | `{}` | Container Security Context |
 | service.port | int | `11434` | Service port |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
                 {{- $limits = merge $limits $gpuLimit }}
               {{- end }}
             {{- end }}
-            {{- $ressources := merge .Values.resources (dict "limits" $limits) }}
+            {{- $ressources := deepCopy (dict "limits" $limits) | mergeOverwrite .Values.resources }}
             {{- toYaml $ressources | nindent 12 }}
           {{- end}}
           volumeMounts:

--- a/values.yaml
+++ b/values.yaml
@@ -128,20 +128,20 @@ ingress:
 # ref: http://kubernetes.io/docs/user-guide/compute-resources/
 resources:
   # Pod requests
-  requests:
+  requests: {}
     # -- Memory request
-    memory: 4096Mi
+    # memory: 4096Mi
 
     # -- CPU request
-    cpu: 2000m
+    # cpu: 2000m
 
   # Pod limit
-  limits:
+  limits: {}
     # -- Memory limit
-    memory: 8192Mi
+    # memory: 8192Mi
 
     # -- CPU limit
-    cpu: 4000m
+    # cpu: 4000m
 
 # Configure extra options for liveness probe
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes


### PR DESCRIPTION
Hey there,

In the current implementation adapting the `resources` definition for granting unlimited access to the host resources could be a bit tricky. This PR proposes a new approach to streamline this process:
 * remove the default `limits` and `requests` resources definition in `values.yaml`
 * if the `resources` section is custom defined, don't bring in the defaults

Let's assume the following custom `values.yaml`
```
ollama:
  gpu:
    enabled: true
    type: 'nvidia'
    number: 1
  models:
    - gemma:7b

persistentVolume:
  enabled: true
  size: 30Gi
  storageClass: "premium-rwo"

image:
  pullPolicy: Always
```

The rendered resources section will be the following:
```
          resources:
            limits:
              cpu: 4000m
              memory: 8192Mi
              nvidia.com/gpu: 1
            requests:
              cpu: 2000m
              memory: 4096Mi
```

In a situation where the host is fully dedicated to Ollama, a use might want to remove `limits` and `requests` while keeping the GPU. Let's now assume a value file where resources' limits and requests are define empty.

```
resources:
  limits: {}
  requests: {}
```

Without this patch the result is the following, effectively the default values are still present.
```
      resources:
            limits:
              cpu: 4000m
              memory: 8192Mi
              nvidia.com/gpu: 1
            requests:
              cpu: 2000m
              memory: 4096Mi
```

With this patch, follows the corrected outcome:
```
          resources:
            limits:
              nvidia.com/gpu: 1
            requests: {}
```