### PR TITLE
feat: specify nodePort for service.nodePort

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ ingress:
 | securityContext | object | `{}` | Container Security Context |
 | service.port | int | `11434` | Service port |
 | service.type | string | `"ClusterIP"` | Service type |
+| service.nodePort | int | `31434` | Service nodePort when service.type is NodePort |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if contains "NodePort" .Values.service.type }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
   selector:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -11,5 +11,8 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "ollama.selectorLabels" . | nindent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -98,7 +98,7 @@ service:
   port: 11434
 
   # -- Service node port when service type is 'NodePort'
-  nodePort: # 31434
+  nodePort: 31434
 
 # Configure the ingress resource that allows you to access the
 ingress:

--- a/values.yaml
+++ b/values.yaml
@@ -97,6 +97,9 @@ service:
   # -- Service port
   port: 11434
 
+  # -- Service node port when service type is 'NodePort'
+  nodePort: # 31434
+
 # Configure the ingress resource that allows you to access the
 ingress:
   # -- Enable ingress controller resource


### PR DESCRIPTION
Hello,

I've added support for using a fixed nodePort (`31434`) in this chart, as the current configuration does not allow for specifying a nodePort. Please review the addition of `service.nodePort`.
- I've set the example nodePort to `31434`. Please feel free to adjust it as needed.

And be happy days at Ollama!
