### PR TITLE
Allow overriding deployment.spec.strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ ingress:
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | tolerations | list | `[]` | Tolerations for pod assignment |
+| updateStrategy.type | string | `""` | How to replace existing pods. Can be `Recreate` or `RollingUpdate` |
 | volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
 | volumes | list | `[]` | Additional volumes on the output Deployment definition. |
 ----------------------------------------------

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -8,8 +8,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
-  {{- if .Values.updateStrategy }}
-  strategy: {{ .Values.updateStrategy | quote }}
+  {{- if or .Values.updateStrategy.type .Values.updateStrategy.rollingUpdate }}
+  strategy: {{ .Values.updateStrategy | toYaml | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -8,6 +8,9 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{ .Values.updateStrategy | quote }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "ollama.selectorLabels" . | nindent 6 }}

--- a/values.yaml
+++ b/values.yaml
@@ -285,4 +285,4 @@ affinity: {}
 # -- How to replace existing pods
 updateStrategy:
   # -- Can be "Recreate" or "RollingUpdate". Default is RollingUpdate
-  type: Recreate
+  type: ""

--- a/values.yaml
+++ b/values.yaml
@@ -282,5 +282,7 @@ tolerations: []
 # -- Affinity for pod assignment
 affinity: {}
 
-# -- How to replace existing pods. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
-updateStrategy: ""
+# -- How to replace existing pods
+updateStrategy:
+  # -- Can be "Recreate" or "RollingUpdate". Default is RollingUpdate
+  type: Recreate

--- a/values.yaml
+++ b/values.yaml
@@ -281,3 +281,6 @@ tolerations: []
 
 # -- Affinity for pod assignment
 affinity: {}
+
+# -- How to replace existing pods. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+updateStrategy: ""


### PR DESCRIPTION
Allowing setting `strategy:  Recreate` would be useful in my case so I don't have to have twice the resources requested available for my one replica.