### PR TITLE
fix: models must be a list not a map

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -58,7 +58,7 @@ ollama:
   # models:
   #  - llama2
   #  - mistral
-  models: {}
+  models: []
 
   # -- Add insecure flag for pulling at container startup
   insecure: false


### PR DESCRIPTION
As I understand, in `values.yml`, the `ollama.models` must be a list not a map.

So we can't set any values to it in the current state of the project.