### PR TITLE
feat: support nvidia MIG by introducing `ollama.gpu.nvidiaResource` defaulting to `nvidia.com/gpu`

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,7 +4,7 @@ description: Get up and running with large language models locally.
 
 type: application
 
-version: 0.45.0
+version: 0.46.0
 
 appVersion: "0.2.7"
 
@@ -12,7 +12,7 @@ annotations:
   artifacthub.io/category: ai-machine-learning
   artifacthub.io/changes: |
     - kind: changed
-      description: upgrade ollama to 0.2.7
+      description: add basic support for nvidia MIG
 
 kubeVersion: "^1.16.0-0"
 home: https://ollama.ai/

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ ingress:
 | ollama.gpu.enabled | bool | `false` | Enable GPU integration |
 | ollama.gpu.number | int | `1` | Specify the number of GPU |
 | ollama.gpu.type | string | `"nvidia"` | GPU type: 'nvidia' or 'amd' If 'ollama.gpu.enabled', default value is nvidia If set to 'amd', this will add 'rocm' suffix to image tag if 'image.tag' is not override This is due cause AMD and CPU/CUDA are different images |
+| ollama.gpu.nvidiaResource | string | `"nvidia.com/gpu"` | Resource to use for nvidia cards; change to (example) 'nvidia.com/mig-1g.10gb' to use MIG slice. MIG setup is not done by this chart and best done through nvidia's gpu-operator separately. |
 | ollama.insecure | bool | `false` | Add insecure flag for pulling at container startup |
 | ollama.models | list | `[]` | List of models to pull at container startup The more you add, the longer the container will take to start if models are not present models:  - llama2  - mistral |
 | ollama.mountPath | string | `""` | Override ollama-data volume mount path, default: "/root/.ollama" |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
             {{- $limits := default dict .Values.resources.limits }}
             {{- if .Values.ollama.gpu.enabled }}
               {{- if or (eq .Values.ollama.gpu.type "nvidia") (not .Values.ollama.gpu.type) }}
-                {{- $gpuLimit := dict "nvidia.com/gpu" (.Values.ollama.gpu.number | default 1) }}
+                {{- $gpuLimit := dict (.Values.ollama.gpu.nvidiaResource | default "nvidia.com/gpu") (.Values.ollama.gpu.number | default 1) }}
                 {{- $limits = merge $limits $gpuLimit }}
               {{- end }}
               {{- if eq .Values.ollama.gpu.type "amd" }}
@@ -150,7 +150,7 @@ spec:
       {{- if or .Values.ollama.gpu.enabled .Values.tolerations }}
       tolerations:
         {{- if and .Values.ollama.gpu.enabled (or (eq .Values.ollama.gpu.type "nvidia") (not .Values.ollama.gpu.type)) }}
-        - key: nvidia.com/gpu
+        - key: "{{(.Values.ollama.gpu.nvidiaResource | default "nvidia.com/gpu")}}"
           operator: Exists
           effect: NoSchedule
         {{- end }}

--- a/templates/knative/service.yaml
+++ b/templates/knative/service.yaml
@@ -54,7 +54,7 @@ spec:
             {{- $limits := default dict .Values.resources.limits }}
             {{- if .Values.ollama.gpu.enabled }}
               {{- if or (eq .Values.ollama.gpu.type "nvidia") (not .Values.ollama.gpu.type) }}
-                {{- $gpuLimit := dict "nvidia.com/gpu" (.Values.ollama.gpu.number | default 1) }}
+                {{- $gpuLimit := dict (.Values.ollama.gpu.nvidiaResource | default "nvidia.com/gpu") (.Values.ollama.gpu.number | default 1) }}
                 {{- $limits = merge $limits $gpuLimit }}
               {{- end }}
               {{- if eq .Values.ollama.gpu.type "amd" }}
@@ -121,7 +121,7 @@ spec:
       {{- if or .Values.ollama.gpu.enabled .Values.tolerations }}
       tolerations:
         {{- if and .Values.ollama.gpu.enabled (or (eq .Values.ollama.gpu.type "nvidia") (not .Values.ollama.gpu.type)) }}
-        - key: nvidia.com/gpu
+        - key: "{{(.Values.ollama.gpu.nvidiaResource | default "nvidia.com/gpu")}}"
           operator: Exists
           effect: NoSchedule
         {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -53,6 +53,10 @@ ollama:
     # -- Specify the number of GPU
     number: 1
 
+    # -- only for nvidia cards; change to (example) 'nvidia.com/mig-1g.10gb' to use MIG slice
+    nvidiaResource: "nvidia.com/gpu"
+    # nvidiaResource: "nvidia.com/mig-1g.10gb" # example
+
   # -- List of models to pull at container startup
   # The more you add, the longer the container will take to start if models are not present
   # models:


### PR DESCRIPTION
#### feat: support nvidia MIG by introducing `ollama.gpu.nvidiaResource` defaulting to `nvidia.com/gpu`

- shouldn't change anything for non-MIG scenarios
- one could set `ollama.gpu.nvidiaResource: "nvidia.com/mig-1g.10gb"` to use a MIG slice instead
- this only allows _using_ MIG slices for Ollama, MIG setup itself is out of scope, best done with nvidia's gpu-operator separately
- bump chart version; describe changes for artifacthub.io; update README.md with new option

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>

**Checklist:**

* [x] I updated the `artifacthub.io/changes` in _Chart.yml_
* [x] Optional: I updated _README.md_