### PR TITLE
chore: add missing ollama.mountPath to knative service

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,6 +13,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: add basic support for nvidia MIG
+    - kind: fixed
+      description: missing ollama.mountPath to knative service
 
 kubeVersion: "^1.16.0-0"
 home: https://ollama.ai/

--- a/templates/knative/service.yaml
+++ b/templates/knative/service.yaml
@@ -67,7 +67,7 @@ spec:
           {{- end}}
           volumeMounts:
             - name: ollama-data
-              mountPath: /root/.ollama
+              mountPath: {{ .Values.ollama.mountPath | default "/root/.ollama" }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
**Summary of changes:**
- add missing `ollama.mountPath` for ollama-data volume mount to knative service (missed from https://github.com/otwld/ollama-helm/pull/73)

**Checklist:**

* [x] I updated the `artifacthub.io/changes` in _Chart.yml_
* [ ] Optional: I updated _README.md_