### PR TITLE
feat: add `.Values.persistentVolume.volumeName`

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,7 +12,7 @@ annotations:
   artifacthub.io/category: ai-machine-learning
   artifacthub.io/changes: |
     - kind: changed
-      description: upgrade ollama to 0.3.6
+      description: add .Values.persistentVolume.volumeName
 
 kubeVersion: "^1.16.0-0"
 home: https://ollama.ai/

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ ingress:
 | persistentVolume.storageClass | string | `""` | Ollama server data Persistent Volume Storage Class If defined, storageClassName: <storageClass> If set to "-", storageClassName: "", which disables dynamic provisioning If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.  (gp2 on AWS, standard on GKE, AWS & OpenStack) |
 | persistentVolume.subPath | string | `""` | Subdirectory of Ollama server data Persistent Volume to mount Useful if the volume's root directory is not empty |
 | persistentVolume.volumeMode | string | `""` | Ollama server data Persistent Volume Binding Mode If defined, volumeMode: <volumeMode> If empty (the default) or set to null, no volumeBindingMode spec is set, choosing the default mode. |
+| persistentVolume.volumeName | string | `""` | Ollama server Persistent Volume name; can be used to force-attach the created PVC to a specific PV. |
 | podAnnotations | object | `{}` | Map of annotations to add to the pods |
 | podLabels | object | `{}` | Map of labels to add to the pods |
 | podSecurityContext | object | `{}` | Pod Security Context |

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -23,6 +23,9 @@ spec:
 {{- if .Values.persistentVolume.volumeMode }}
   volumeMode: "{{ .Values.persistentVolume.volumeMode }}"
 {{- end }}
+{{- if .Values.persistentVolume.volumeName }}
+  volumeName: "{{ .Values.persistentVolume.volumeName }}"
+{{- end }}
   resources:
     requests:
       storage: "{{ .Values.persistentVolume.size }}"

--- a/values.yaml
+++ b/values.yaml
@@ -296,6 +296,11 @@ persistentVolume:
   # Useful if the volume's root directory is not empty
   subPath: ""
 
+  # -- Pre-existing PV to attach this claim to
+  # Useful if a CSI auto-provisions a PV for you and you want to always
+  # reference the PV moving forward
+  volumeName: ""
+
 # -- Node labels for pod assignment.
 nodeSelector: {}
 


### PR DESCRIPTION
**Summary of changes:**

Add `.Values.persistentVolume.volumeName` to `pvc.yaml`.

I have a usecase where I configure the PVC to use a SMB CSI/share. I'd like to be able to have the created PVC to always reference this PV, without needing to configure any extra claim templates/manifests.

**Checklist:**

* [x] I updated the `artifacthub.io/changes` in _Chart.yml_
* [x] Optional: I updated _README.md_