### PR TITLE
Support envFrom in container spec

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
             {{- with .Values.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          envFrom:
+            {{- with .Values.extraEnvFrom }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           args:
           {{- with .Values.extraArgs }}
              {{- toYaml . | nindent 12 }}

--- a/values.yaml
+++ b/values.yaml
@@ -270,6 +270,10 @@ extraEnv: []
 #  - name: OLLAMA_DEBUG
 #    value: "1"
 
+# -- Additionl environment variables from external sources (like ConfigMap)
+extraEnvFrom: []
+#  - configMapRef:
+#      name: my-env-configmap
 
 # Enable persistence using Persistent Volume Claims
 # ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/


### PR DESCRIPTION
Support pulling in env variables from a ConfigMap rather than specifying each one.  Added support for `envFrom` in the deployment and values.yaml