### PR TITLE
fix: helm linting failed with PVC enabled

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,6 +16,8 @@ annotations:
       links:
         - name: Ollama release v0.5.7
           url: https://github.com/ollama/ollama/releases/tag/v0.5.7
+    - kind: fixed
+      description: broken helm linting with enabled pvcs
 
 kubeVersion: "^1.16.0-0"
 home: https://ollama.ai/

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,17 +1,17 @@
----
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "ollama.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className }}
   {{- end }}
 {{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+---
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
+{{- else }}
 apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -1,6 +1,5 @@
+{{- if (and .Values.persistentVolume.enabled (not .Values.persistentVolume.existingClaim)) -}}
 ---
-{{- if .Values.persistentVolume.enabled -}}
-{{- if not .Values.persistentVolume.existingClaim -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -31,5 +30,4 @@ spec:
   resources:
     requests:
       storage: "{{ .Values.persistentVolume.size }}"
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
**Summary of changes:**

When running helm lint with persistent volumes enabled, there were errors in the pvc.yaml template file. This was due to the whitespace control in certain situations. I fixed it for the pvc file and checked through the others for similar situations.

You can reproduce this by running helm lint with pvcs enabled:

```
➜  ollama-helm git:(56282c7) helm lint --set persistentVolume.enabled=true
==> Linting .
[ERROR] templates/pvc.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: v1

Error: 1 chart(s) linted, 1 chart(s) failed
```

And after my changes:

```
➜  ollama-helm git:(main) helm lint --set persistentVolume.enabled=true
==> Linting .

1 chart(s) linted, 0 chart(s) failed
```

**Checklist:**

* [x] I updated the `artifacthub.io/changes` annotation in _Chart.yml_ according to the [documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations)
* [n/a] Optional: I updated in _README.md_ the [Helm Values](https://github.com/otwld/ollama-helm?tab=readme-ov-file#helm-values)