### PR TITLE
fix: drop xargs from postStart script

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,23 +4,18 @@ description: Get up and running with large language models locally.
 
 type: application
 
-version: 1.7.0
+version: 1.7.1
 
 appVersion: "0.5.12"
 
 annotations:
   artifacthub.io/category: ai-machine-learning
   artifacthub.io/changes: |
-    - kind: changed
-      description: upgrade app version to 0.5.12
+    - kind: fixed
+      description: remove xargs from postStart script
       links:
-        - name: Ollama release v0.5.12
-          url: https://github.com/ollama/ollama/releases/tag/v0.5.12
-    - kind: added
-      description: add service.labels
-      links:
-        - name: PR#144
-          url: https://github.com/otwld/ollama-helm/pull/144
+        - name: PR#149
+          url: https://github.com/otwld/ollama-helm/pull/149
 
 kubeVersion: "^1.16.0-0"
 home: https://ollama.ai/

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -73,52 +73,6 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Create the pull model list
-*/}}
-{{- define "ollama.modelPullList" -}}
-{{- with .Values.ollama.models.pull -}}
-{{- . | uniq | join " " -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create the run model list
-*/}}
-{{- define "ollama.modelRunList" -}}
-{{- with .Values.ollama.models.run -}}
-{{- . | uniq | join " " -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create the create template model list
-*/}}
-{{- define "ollama.modelCreateTemplateList" -}}
-{{- $createModels := .Values.ollama.models.create | default dict -}}
-{{- $modelNames := list -}}
-{{- range $createModels -}}
-{{- if .template -}}
-  {{- $modelNames = append $modelNames .name -}}
-{{- end -}}
-{{- end -}}
-{{- $modelNames | uniq | join " " -}}
-{{- end -}}
-
-{{/*
-Create the create configMap model list
-*/}}
-{{- define "ollama.modelCreateConfigMapList" -}}
-{{- $createModels := .Values.ollama.models.create | default dict -}}
-{{- $modelNames := list -}}
-{{- range $createModels -}}
-{{- if .configMapRef -}}
-  {{- $modelNames = append $modelNames .name -}}
-{{- end -}}
-{{- end -}}
-{{- $modelNames | uniq | join " " -}}
-{{- end -}}
-
-{{/*
 Models mount path
 */}}
 {{- define "ollama.modelsMountPath" -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -162,26 +162,31 @@ spec:
                     while ! /bin/ollama ps > /dev/null 2>&1; do
                       sleep 5
                     done
+
                     {{- if .Values.ollama.models.pull }}
-                    echo "{{ include "ollama.modelPullList" . }}" | xargs -n1 /bin/ollama pull {{ternary "--insecure" "" .Values.ollama.insecure | toString }}
+                    {{- range .Values.ollama.models.pull }}
+                    /bin/ollama pull {{ternary "--insecure" "" $.Values.ollama.insecure | toString }} {{ . }}
                     {{- end }}
+                    {{- end }}
+
                     {{- if .Values.ollama.models.create }}
-                    {{- range $.Values.ollama.models.create }}
+                    {{- range .Values.ollama.models.create }}
                     {{- if .template }}
                     cat <<EOF > {{ include "ollama.modelsMountPath" $ }}/{{ .name }}
                     {{- .template | nindent 20 }}
                     EOF
-                    {{- end}}
+                    /bin/ollama create {{ .name }} -f {{ include "ollama.modelsMountPath" . }}/{{ .name }}
                     {{- end }}
-                    {{- if (include "ollama.modelCreateTemplateList" .)}}
-                    echo "{{ include "ollama.modelCreateTemplateList" . }}" | xargs -n1 -I {} /bin/ollama create {} -f {{ include "ollama.modelsMountPath" . }}/{}
-                    {{- end }}
-                    {{- if (include "ollama.modelCreateConfigMapList" .)}}
-                    echo "{{ include "ollama.modelCreateConfigMapList" . }}" | xargs -n1 -I {} /bin/ollama create {} -f /models/{}
+                    {{- if .configMapRef }}
+                    /bin/ollama create {{ .name }} -f /models/{{ .name }}
                     {{- end }}
                     {{- end }}
+                    {{- end }}
+
                     {{- if .Values.ollama.models.run }}
-                    echo "{{ include "ollama.modelRunList" . }}" | xargs -n1 /bin/ollama run
+                    {{- range .Values.ollama.models.run }}
+                    /bin/ollama run {{ . }}
+                    {{- end }}
                     {{- end }}
           {{- end }}
           {{- end }}

--- a/templates/knative/service.yaml
+++ b/templates/knative/service.yaml
@@ -118,25 +118,29 @@ spec:
                       sleep 5
                     done
                     {{- if .Values.ollama.models.pull }}
-                    echo "{{ include "ollama.modelPullList" . }}" | xargs -n1 /bin/ollama pull {{ternary "--insecure" "" .Values.ollama.insecure | toString }}
+                    {{- range .Values.ollama.models.pull }}
+                    /bin/ollama pull {{ternary "--insecure" "" $.Values.ollama.insecure | toString }} {{ . }}
                     {{- end }}
+                    {{- end }}
+
                     {{- if .Values.ollama.models.create }}
-                    {{- range $.Values.ollama.models.create }}
+                    {{- range .Values.ollama.models.create }}
                     {{- if .template }}
                     cat <<EOF > {{ include "ollama.modelsMountPath" $ }}/{{ .name }}
                     {{- .template | nindent 20 }}
                     EOF
-                    {{- end}}
+                    /bin/ollama create {{ .name }} -f {{ include "ollama.modelsMountPath" . }}/{{ .name }}
                     {{- end }}
-                    {{- if (include "ollama.modelCreateTemplateList" .)}}
-                    echo "{{ include "ollama.modelCreateTemplateList" . }}" | xargs -n1 -I {} /bin/ollama create {} -f {{ include "ollama.modelsMountPath" . }}/{}
-                    {{- end }}
-                    {{- if (include "ollama.modelCreateConfigMapList" .)}}
-                    echo "{{ include "ollama.modelCreateConfigMapList" . }}" | xargs -n1 -I {} /bin/ollama create {} -f /models/{}
+                    {{- if .configMapRef }}
+                    /bin/ollama create {{ .name }} -f /models/{{ .name }}
                     {{- end }}
                     {{- end }}
+                    {{- end }}
+
                     {{- if .Values.ollama.models.run }}
-                    echo "{{ include "ollama.modelRunList" . }}" | xargs -n1 /bin/ollama run
+                    {{- range .Values.ollama.models.run }}
+                    /bin/ollama run {{ . }}
+                    {{- end }}
                     {{- end }}
           {{- end }}
           {{- end }}


### PR DESCRIPTION
xargs has inconsistant behaviour handling whitespace:
* When given argument `-I {}` it no longer splits on spaces properly.
* When given `-d" "` to force it to split on spaces it doesn't handle single values properly.

This problem identifies itself when there are multiple create models defined in the values today because xargs tries to put every model name in a single create command.

This commit drops the use of xargs completely from the script and uses the helm templating to create all the commands explictly.

**Summary of changes:**

**Checklist:**

* [x] I updated the `artifacthub.io/changes` annotation in _Chart.yml_ according to the [documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations)
* [ ] Optional: I updated in _README.md_ the [Helm Values](https://github.com/otwld/ollama-helm?tab=readme-ov-file#helm-values)