### PR TITLE
fix: replace probe port with .Values.ollama.port

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -134,7 +134,7 @@ spec:
           livenessProbe:
             httpGet:
               path: {{ .Values.livenessProbe.path }}
-              port: http
+              port: {{ .Values.ollama.port }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -145,7 +145,7 @@ spec:
           readinessProbe:
             httpGet:
               path: {{ .Values.readinessProbe.path }}
-              port: http
+              port: {{ .Values.ollama.port }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}


### PR DESCRIPTION
**Summary of changes:**

Replace "http" with {{ .Values.ollama.port }} in livenessProbe and readienessProbe

**Checklist:**

* [ ] I updated the `artifacthub.io/changes` annotation in _Chart.yml_ according to the [documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations)
* [ ] Optional: I updated in _README.md_ the [Helm Values](https://github.com/otwld/ollama-helm?tab=readme-ov-file#helm-values)