### PR TITLE
Fix folder references for post start hooks on using custom model templates

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,15 +4,15 @@ description: Get up and running with large language models locally.
 
 type: application
 
-version: 1.22.0
+version: 1.23.0
 
 appVersion: "0.9.3"
 
 annotations:
   artifacthub.io/category: ai-machine-learning
   artifacthub.io/changes: |
-    - kind: added
-      description: add support for setting priorityClassName in Deployment
+    - kind: fixed
+      description: fix post start hooks when using ollama.create modelfiles and custom directory paths
 
 kubeVersion: "^1.16.0-0"
 home: https://ollama.ai/

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -76,5 +76,5 @@ Create the name of the service account to use
 Models mount path
 */}}
 {{- define "ollama.modelsMountPath" -}}
-{{- printf "%s/models" ( default "/root/.ollama") }}
+{{- printf "%s/models" ( .Values.ollama.mountPath | default "/root/.ollama") }}
 {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -76,5 +76,5 @@ Create the name of the service account to use
 Models mount path
 */}}
 {{- define "ollama.modelsMountPath" -}}
-{{- printf "%s/models" ( .Values.ollama.mountPath | default "/root/.ollama") }}
+{{- printf "%s/models" (((.Values).ollama).mountPath | default "/root/.ollama") }}
 {{- end -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -183,7 +183,7 @@ spec:
                     cat <<EOF > {{ include "ollama.modelsMountPath" $ }}/{{ .name }}
                     {{- .template | nindent 20 }}
                     EOF
-                    /bin/ollama create {{ .name }} -f {{ include "ollama.modelsMountPath" . }}/{{ .name }}
+                    /bin/ollama create {{ .name }} -f {{ include "ollama.modelsMountPath" $ }}/{{ .name }}
                     {{- end }}
                     {{- if .configMapRef }}
                     /bin/ollama create {{ .name }} -f /models/{{ .name }}


### PR DESCRIPTION
Not a helm pro here by any means but I believe the ollama.modelsMountPath is missing a condition to check when the mountPath has been changed thereby affecting postStart hooks in the ollama.create functionality.  https://github.com/otwld/ollama-helm/blob/c71a8620c99796c24bda7f909176ee715c747015/templates/deployment.yaml#L183 evaluates to a /root/ path. So then this PR would match the behavior to https://github.com/otwld/ollama-helm/blob/c71a8620c99796c24bda7f909176ee715c747015/templates/deployment.yaml#L123

**Summary of changes:**
Update _helpers.tpl file to respect custom mountPaths when using ollama.create templates/modelfiles.
Update deployment.yaml to retrieve same variable value
Update Chart.yaml per PR requirements.

Please let me know if I need to change anything here - I was able to run this locally against my desired chart values (with custom templates + non root) - thanks

**Checklist:**

* [x] I updated the `artifacthub.io/changes` annotation in _Chart.yml_ according to the [documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations)
* [ ] Optional: I updated in _README.md_ the [Helm Values](https://github.com/otwld/ollama-helm?tab=readme-ov-file#helm-values)