### PR TITLE
fix: dra ga support for k8s 1.34 or later

### DIFF
--- a/templates/resourceclaimtemplate.yaml
+++ b/templates/resourceclaimtemplate.yaml
@@ -1,6 +1,10 @@
 {{- if and .Values.ollama.gpu.enabled .Values.ollama.gpu.draEnabled (not .Values.ollama.gpu.draExistingClaimTemplate) -}}
 ---
+{{- if semverCompare ">=1.34-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: resource.k8s.io/v1
+{{- else }}
 apiVersion: resource.k8s.io/v1beta1
+{{- end }}
 kind: ResourceClaimTemplate
 metadata:
   name: {{ template "ollama.fullname" . }}


### PR DESCRIPTION
**Summary of changes:**

DRA will GA soon with 1.34 release. Then api version will upgrade v1beta1 to v1.

https://cloudsmith.com/blog/kubernetes-1-34-what-you-need-to-know

https://kubernetes.io/blog/2025/07/28/kubernetes-v1-34-sneak-peek/

> Once this feature has graduated, the resource.k8s.io/v1 APIs will be available by default.

**Checklist:**

* [ X] I updated the `artifacthub.io/changes` annotation in _Chart.yml_ according to the [documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations)
* [ X] Optional: I updated in _README.md_ the [Helm Values](https://github.com/otwld/ollama-helm?tab=readme-ov-file#helm-values)