### PR TITLE
fix: resolve argocd diffs in httproute #250

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -11,6 +11,8 @@ appVersion: 0.23.2
 annotations:
   artifacthub.io/category: ai-machine-learning
   artifacthub.io/changes: |
+    - kind: added
+      description: add missing fields to httproute to fix argo diff
     - kind: changed
       description: upgrade app version to v0.23.2
       links:

--- a/templates/httpRoute.yaml
+++ b/templates/httpRoute.yaml
@@ -35,6 +35,9 @@ spec:
         {{- toYaml .backendRefs | nindent 8 }}
         {{- else }}
         - name: {{ include "ollama.fullname" $ }}
+          group: ""
+          kind: Service
+          weight: 1
           port: {{ $.Values.service.port }}
         {{- end }}
     {{- end }}
@@ -45,6 +48,9 @@ spec:
             value: /
       backendRefs:
         - name: {{ include "ollama.fullname" . }}
+          group: ""
+          kind: Service
+          weight: 1
           port: {{ .Values.service.port }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
**Summary of changes:**
Fix argocd diff in HTTPRoute by adding "group", "kind", and "weight" fields to spec.rules[].backendRefs. This fixes this issue https://github.com/otwld/ollama-helm/issues/250

**Checklist:**

* [x] I updated the `artifacthub.io/changes` annotation in _Chart.yml_ according to the [documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations)
* [ ] Optional: I updated in _README.md_ the [Helm Values](https://github.com/otwld/ollama-helm?tab=readme-ov-file#helm-values)